### PR TITLE
Rename cli command "snapshots" to "backups"

### DIFF
--- a/samba-backup/rootfs/scripts/main.sh
+++ b/samba-backup/rootfs/scripts/main.sh
@@ -31,7 +31,7 @@ function create-snapshot {
 
     # run the command
     bashio::log.info "Creating snapshot \"${SNAP_NAME}\""
-    SLUG="$(ha snapshots new "${args[@]}" --raw-json | jq -r .data.slug)"
+    SLUG="$(ha backups new "${args[@]}" --raw-json | jq -r .data.slug)"
 }
 
 # ------------------------------------------------------------------------------
@@ -66,13 +66,13 @@ function cleanup-snapshots-local {
 
     [ "$KEEP_LOCAL" == "all" ] && return 0
 
-    snaps=$(ha snapshots --raw-json | jq -c '.data.snapshots[] | {date,slug,name}' | sort -r)
+    snaps=$(ha backups --raw-json | jq -c '.data.snapshots[] | {date,slug,name}' | sort -r)
     bashio::log.debug "$snaps"
 
     echo "$snaps" | tail -n +$(($KEEP_LOCAL + 1)) | while read backup; do
         slug=$(echo $backup | jq -r .slug)
         bashio::log.info "Deleting ${slug} local"
-        run-and-log "ha snapshots remove ${slug}"
+        run-and-log "ha backups remove ${slug}"
     done
 }
 

--- a/samba-backup/rootfs/scripts/sensor.sh
+++ b/samba-backup/rootfs/scripts/sensor.sh
@@ -70,7 +70,7 @@ function update-sensor {
     CURRENT_STATUS="$status"
 
     if bashio::var.has_value "${all}"; then
-        if response=$(ha snapshots --raw-json | jq ".data.snapshots[].slug"); then
+        if response=$(ha backups --raw-json | jq ".data.snapshots[].slug"); then
             BACKUPS_LOCAL=$(echo "$response" | wc -l)
         fi
 


### PR DESCRIPTION
As the PR here https://github.com/home-assistant/cli/pull/301
The command `ha snapshots` will be replaced by `ha backups`

Renaming commands for **backup** creation, deletion and listing.