### PR TITLE
Add wake on LAN option to wake up the host systen

### DIFF
--- a/samba-backup/CHANGELOG.md
+++ b/samba-backup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.3.0
+
+- Add wake on LAN option to wake up the host system before copying the backup
+
 ## 5.2.0
 
 - Add dutch translation

--- a/samba-backup/DOCS.md
+++ b/samba-backup/DOCS.md
@@ -8,6 +8,10 @@ Create backups and store them on a Samba share.
 
 The hostname/URL of the Samba share.
 
+### Option: `host_mac`
+
+The MAC address of the host. This option should be used in conjunction with the 'wol' option.
+
 ### Option: `share`
 
 The name of the Samba share.
@@ -69,6 +73,10 @@ If specified the backups will be password-protected.
 ### Option: `workgroup`
 
 The workgroup to use for authentication. Only set this option if not using the default workgroup `WORKGROUP`.
+
+### Option: `wol`
+
+Enable this option to wake up the host before copying the backup to the share using Wake-on-LAN (WOL). Also, be sure to specify the 'host_mac' option.
 
 ### Option: `compatibility_mode`
 

--- a/samba-backup/Dockerfile
+++ b/samba-backup/Dockerfile
@@ -14,6 +14,7 @@ RUN \
     && chmod a+x /usr/bin/ha \
     && apk add --no-cache \
         samba-client \
+        awake \
     && chmod a+x /run.sh
 
 # Run script

--- a/samba-backup/config.yaml
+++ b/samba-backup/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Samba Backup
-version: 5.2.0
+version: 5.3.0
 slug: samba_backup
 description: Create backups and store them on a Samba share
 url: https://github.com/thomasmauerer/hassio-addons/tree/master/samba-backup
@@ -12,6 +12,7 @@ arch:
   - i386
 startup: application
 boot: auto
+host_network: true
 homeassistant_api: true
 hassio_api: true
 hassio_role: manager
@@ -41,6 +42,7 @@ options:
   exclude_folders: []
 schema:
   host: str
+  host_mac: str?
   share: str
   target_dir: str
   username: str
@@ -59,4 +61,5 @@ schema:
   workgroup: str?
   compatibility_mode: bool?
   skip_precheck: bool?
+  wol: bool?
   log_level: list(debug|info|warning|error)?

--- a/samba-backup/translations/de.yaml
+++ b/samba-backup/translations/de.yaml
@@ -2,6 +2,9 @@ configuration:
   host:
     name: Host Adresse
     description: DNS Name oder IP Adresse des Hostsystems, NAS, etc. auf dem die Samba Freigabe eingerichtet wurde.
+  host_mac:
+    name: Host MAC
+    description: MAC Adresse des Hostsystems, NAS, etc. auf dem die Samba Freigabe eingerichtet wurde.
   share:
     name: Freigabe
     description: Name der Samba Freigabe.
@@ -44,6 +47,9 @@ configuration:
   compatibility_mode:
     name: Kompatibilitätsmodus
     description: Schaltet Unterstützung für alte Legacy SMB Protokolle ein. NICHT empfohlen!
+  wol:
+    name: Wake on LAN
+    description: Weckt das Hostsystem vor der Sicherung auf. Die Host MAC muss dafür angegeben sein
   skip_precheck:
     name: Checks überspringen
     description: Startet das Add-on ohne Checks ob die Samba Freigabe korrekt eingerichtet wurde.

--- a/samba-backup/translations/en.yaml
+++ b/samba-backup/translations/en.yaml
@@ -3,6 +3,9 @@ configuration:
   host:
     name: Host
     description: The DNS or IP address of the Samba share, NAS, etc.
+  host_mac:
+    name: Host MAC
+    description: MAC address of the Samba share, NAS, etc.
   share:
     name: Share
     description: The name of the share.
@@ -45,6 +48,9 @@ configuration:
   compatibility_mode:
     name: Compatibility mode
     description: Enables old legacy SMB protocols. NOT recommended!
+  wol:
+    name: Wake on LAN
+    description: Wakes up the host system before the backup. The host MAC must be specified for this
   skip_precheck:
     name: Skip precheck
     description: Starts the addon without any checks whether the share is set up correctly.

--- a/samba-backup/translations/nl.yaml
+++ b/samba-backup/translations/nl.yaml
@@ -3,6 +3,9 @@ configuration:
   host:
     name: Host
     description: Het DNS- of IP-adres van de Samba-share, NAS, enz.
+  host_mac:
+    name: Host MAC
+    description: MAC address of the Samba share, NAS, etc.
   share:
     name: Share
     description: De naam van de share.
@@ -45,6 +48,9 @@ configuration:
   compatibility_mode:
     name: Compatibiliteitsmodus
     description: Schakelt oude legacy SMB protocollen in. NIET aanbevolen!
+  wol:
+    name: Wake on LAN
+    description: Wakes up the host system before the backup. The host MAC must be specified for this
   skip_precheck:
     name: Skip precheck
     description: Start de addon zonder enige controle of de share correct is ingesteld.

--- a/samba-backup/translations/sv.yaml
+++ b/samba-backup/translations/sv.yaml
@@ -2,6 +2,9 @@ configuration:
   host:
     name: Värd
     description: IP-adressen till Samba share, NAS, etc.
+  host_mac:
+    name: Host MAC
+    description: MAC address of the Samba share, NAS, etc.
   share:
     name: Utdelning
     description: Namnet på utdelningen share.
@@ -44,6 +47,9 @@ configuration:
   compatibility_mode:
     name: Kompabilitetsläge
     description: Aktiverar äldre SMB protokoll. INTE rekommenderat!
+  wol:
+    name: Wake on LAN
+    description: Wakes up the host system before the backup. The host MAC must be specified for this
   skip_precheck:
     name: Skippa förkontroll
     description: Starta tillägget utan att kontrollera om utdelningen är korret inställd.


### PR DESCRIPTION
Hi Thomas, 

Thanks for the great addon. 

My backup system does not run 24/7, so I was missing the option to wake up my system before copying the backup. 
This PR adds the option to do a WOL before copying the backup to the host system.

A few notes on implementation:

- If WOL is enabled and host_mac is missing, the addon will fail on startup because the addon is misconfigured.
- When the addon pings a DNS name, the ping output may be "ping: bad address". This seems to be a DNS issue. So I added a log message to indicate that the user should use the IP address instead.

The process of doing a WOL is as follows:

1. Check if WOL is enabled

2. Check if host is online

    * If the host is online

       1. Continue copying the backup

    * If host is offline
   
      1. Send WOL
      
      2. Ping host system 100 times
      
      3. Check if host comes up within 100 pings
      
          * Host comes up within 100 pings

            1. Wait another 60 seconds for the host to settle.
            2. Continue copying the backup

          * Host did NOT come up after 100 pings
      
             1. Cancel the backup copy with a warning


Thanks for reviewing my PR and just let me know if there is anything to change. 