### PR TITLE
Add success and log messages attributes to sensor

### DIFF
--- a/samba-backup/config.yaml
+++ b/samba-backup/config.yaml
@@ -17,6 +17,7 @@ hassio_api: true
 hassio_role: manager
 stdin: true
 map:
+  - addon_config:rw
   - backup:rw
 image: thomasmauerer/samba-backup-{arch}
 init: false

--- a/samba-backup/rootfs/run.sh
+++ b/samba-backup/rootfs/run.sh
@@ -26,8 +26,8 @@ function run-backup {
             || update-sensor "${SAMBA_STATUS[3]}" "ALL"
 
         sleep 10
-        update-sensor "${SAMBA_STATUS[0]}"
         bashio::log.info "Backup finished"
+        update-sensor "${SAMBA_STATUS[0]}"
     ) 200>/tmp/samba_backup.lockfile
 }
 

--- a/samba-backup/rootfs/scripts/sensor.sh
+++ b/samba-backup/rootfs/scripts/sensor.sh
@@ -4,7 +4,7 @@
 declare SAMBA_STATUS=(IDLE RUNNING SUCCEEDED FAILED)
 declare SENSOR_NAME="sensor.samba_backup"
 declare SENSOR_URL="/core/api/states/${SENSOR_NAME}"
-declare STORAGE_FILE="/backup/.samba_backup.sensor"
+declare STORAGE_FILE="/config/.samba_backup.sensor"
 
 declare CURRENT_STATUS
 

--- a/samba-backup/rootfs/scripts/sensor.sh
+++ b/samba-backup/rootfs/scripts/sensor.sh
@@ -13,7 +13,7 @@ declare BACKUPS_REMOTE="0"
 declare TOTAL_SUCCESS="0"
 declare TOTAL_FAIL="0"
 declare LAST_BACKUP="never"
-declare LAST_BACKUP_SUCCESSFUL="false"
+declare LAST_BACKUP_SUCCESSFUL=false
 declare LAST_LOG_MESSAGES=""
 
 
@@ -113,7 +113,7 @@ function update-sensor {
     --arg ts "$TOTAL_SUCCESS" \
     --arg tf "$TOTAL_FAIL" \
     --arg lb "$LAST_BACKUP" \
-    --arg lbs "$LAST_BACKUP_SUCCESSFUL" \
+    --argjson lbs "$LAST_BACKUP_SUCCESSFUL" \
     --arg llm "$LAST_LOG_MESSAGES" \
     '{
         "state": $s,

--- a/samba-backup/rootfs/scripts/sensor.sh
+++ b/samba-backup/rootfs/scripts/sensor.sh
@@ -103,6 +103,22 @@ function update-sensor {
             LAST_BACKUP_SUCCESSFUL=false
         fi
 
+        # The following line retrieves and processes the logs from the samba backup addon in Home Assistant.
+        # It removes any ANSI escape codes using 'sed' and extracts logs related to a backup operation using 'awk'.
+        # The logs are stored in the LAST_LOG_MESSAGES variable for further use.
+        
+        # '/Backup running/': This is an AWK pattern that looks for lines containing "Backup running".
+        # When found, the associated action block is executed.
+        
+        # '{data=""; found=1}': Action block for lines containing "Backup running".
+        # It initializes the variable 'data' as an empty string and sets 'found' to 1 to mark the start of capturing log messages.
+        
+        # 'found{data = data $0 RS}': Action block for lines after "Backup running" has been found.
+        # It appends the current line ('$0') and the record separator ('RS', representing newline) to 'data'.
+        # This accumulates log messages related to the ongoing backup operation.
+        
+        # 'END{printf "%s", data}': Action block executed at the end of processing all input lines.
+        # It uses 'printf' to print the accumulated 'data' variable, ensuring only the backup-related log messages are captured.
         LAST_LOG_MESSAGES=$(echo -e "$(ha addons logs self | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')" | awk '/Backup running/{data=""; found=1} found{data = data $0 RS} END{printf "%s", data}')
     fi
 


### PR DESCRIPTION
Hi Thomas,

I have added the following attributes to the sensor:
- LAST_BACKUP_SUCCESSFUL -> Display in a simple boolean value if the last backup was successful
- LAST_LOG_MESSAGES -> Show the last log messages starting with the last "Backup running ...".

This way it's easier to check if something failed and see the error messages immediately.
For example, I have a node-red flow that sends me a notification after the backup is done. If something failed, the log message is attached to the notification.

Some notes on the implementation:

- I changed the path of the .samba_backup.sensor file to the config folder instead of the backup folder. The backup folder is used by HA and I think this folder should not be used by addon for custom files.
- Known issue: The last log message "Backup finished" is not in the LAST_LOG_MESSAGES attribute. I think the output via `bashio::logs.info` and calling `ha addon logs self` is too close together. Even with a sleep of 20 seconds I cannot get it to show up in LAST_LOG_MESSAGES.

Thanks again for reviewing :+1: